### PR TITLE
change to prevent crash on add

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ function findOneByKey (arr, key, value) {
 }
 
 function requestedAttributes (req) {
-  var result
+  var result = []
   req.groups.some(function (group) {
     if (group.tag === C.OPERATION_ATTRIBUTES_TAG) {
       group.attributes.some(function (attr) {


### PR DESCRIPTION
It at least stops it from crashing. Windows still says cannot connect to the printer. Idk what the code does well enough for something better. Here's a starting point. Let's not merge this yet, but start a conversation. Let's fix this (#1).