### PR TITLE
Allow user to define a function to check any operation before continuing

### DIFF
--- a/lib/bind.js
+++ b/lib/bind.js
@@ -101,19 +101,21 @@ function router (printer, req, res) {
 
   if (body.version.major !== 1) return res.send(C.SERVER_ERROR_VERSION_NOT_SUPPORTED)
 
-  switch (body.operationId) {
-    // Printer Operations
-    case C.PRINT_JOB: return operations.printJob(printer, req, res)
-    case C.VALIDATE_JOB: return operations.validateJob(printer, req, res)
-    case C.GET_PRINTER_ATTRIBUTES: return operations.getPrinterAttributes(printer, req, res)
-    case C.GET_JOBS: return operations.getJobs(printer, req, res)
+  printer.operation(req, res, function () {
+    switch (body.operationId) {
+      // Printer Operations
+      case C.PRINT_JOB: return operations.printJob(printer, req, res)
+      case C.VALIDATE_JOB: return operations.validateJob(printer, req, res)
+      case C.GET_PRINTER_ATTRIBUTES: return operations.getPrinterAttributes(printer, req, res)
+      case C.GET_JOBS: return operations.getJobs(printer, req, res)
 
-    // Job Operations
-    case C.CANCEL_JOB: return operations.cancelJob(printer, req, res)
-    case C.GET_JOB_ATTRIBUTES: return operations.getJobAttributes(printer, req, res)
+      // Job Operations
+      case C.CANCEL_JOB: return operations.cancelJob(printer, req, res)
+      case C.GET_JOB_ATTRIBUTES: return operations.getJobAttributes(printer, req, res)
 
-    default: res.send(C.SERVER_ERROR_OPERATION_NOT_SUPPORTED)
-  }
+      default: res.send(C.SERVER_ERROR_OPERATION_NOT_SUPPORTED)
+    }
+  });
 }
 
 function send (printer, req, res, statusCode, _groups) {

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -115,7 +115,7 @@ function router (printer, req, res) {
 
       default: res.send(C.SERVER_ERROR_OPERATION_NOT_SUPPORTED)
     }
-  });
+  })
 }
 
 function send (printer, req, res, statusCode, _groups) {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -17,6 +17,7 @@ function Printer (opts) {
   else if (typeof opts === 'string') opts = { name: opts }
   if (!('zeroconf' in opts)) opts.zeroconf = true
   if (!('fallback' in opts)) opts.fallback = true
+  if (!('operation' in opts)) opts.operation = (req, res, next) => { next() }
 
   EventEmitter.call(this)
 
@@ -31,6 +32,7 @@ function Printer (opts) {
   this.state = C.STOPPED
   this.server = opts.server
   this.fallback = opts.fallback
+  this.operation = opts.operation
 
   bind(this)
 }


### PR DESCRIPTION
This is just a suggestion, you're free to decide if you like it or not.

This creates an option (optional..) called `operation` with a prototype similar to express (`req, res, next`) that is called before any operation and enables the developer to inspect the HTTP request and decide if it should continue (`next`) or respond in another way (using `res`).

Here's a stupid example:

``` js
var printer = new Printer({
    name      : "My Awesome Printer",
    operation : function (req, res, next) {
        if (!req.headers.authorization) {
            console.log("no guests! you need to auth!");

            // it could be DIGEST instead of BASIC
            res.writeHead(401, "Not Authorized", {
                "WWW-Authenticate": "Basic realm=\"My Awesome Printer\""
            });
            return res.end();
        } else {
            console.log("I don't know who you are, I have to base64 decode but at least you typed a username");
        }

        return next();
    }
});
```
