### PR TITLE
Added support for shutting down server and bonjour service / onError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ string or an object containing:
   be necessary in a perfect world, but some versions of Windows doesn't
   like connecting to a server running a different version of the IPP
   protocol than it self (default: `true`)
+- `onerror` - Function. Callback for catching [`http.Server`](https://nodejs.org/api/http.html#http_class_http_server) errors. Useful for catching server initialization errors if there are network or configuration problems.
 
 Note that the IPP standard specifies port 631 as the default IPP port,
 but most IPP clients are fine with connecting to another port.
@@ -164,6 +165,14 @@ An array of all jobs handled by the printer.
 #### `printer.server`
 
 An instance of [`http.Server`](https://nodejs.org/api/http.html#http_class_http_server).
+
+#### `printer.destroy`
+
+A function to shut down the printer server and bonjour service.
+
+```js
+printer.destroy();
+```
 
 ### Class: Job
 

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -3,6 +3,7 @@
 var util = require('util')
 var os = require('os')
 var http = require('http')
+var serverDestroy = require('server-destroy');
 var Bonjour = require('bonjour')
 var ipp = require('ipp-encoder')
 var debug = require('debug')(require('../package').name)
@@ -21,12 +22,35 @@ module.exports = function (printer) {
     else server.on('listening', onlistening)
   } else {
     server = printer.server = http.createServer(onrequest)
+    server.on('error', onerror)
     server.listen(printer.port, onlistening)
   }
 
+  // Enable destroy method in http server
+  serverDestroy(server)
+
+  // Enhance printer object
+  printer.destroy = destroy
+
   return printer
 
-  function onrequest (req, res) {
+  function onerror(err) {
+    if (printer.onerror) {
+      return printer.onerror(err)
+    }
+
+    throw err
+  }
+
+  function destroy() {
+    printer.stop()
+    bonjour.destroy()
+    server.destroy()
+
+    debug('Printer server destroyed')
+  }
+
+  function onrequest(req, res) {
     debug('HTTP request: %s %s', req.method, req.url)
 
     if (req.method !== 'POST') {

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -3,7 +3,7 @@
 var util = require('util')
 var os = require('os')
 var http = require('http')
-var serverDestroy = require('server-destroy');
+var serverDestroy = require('server-destroy')
 var Bonjour = require('bonjour')
 var ipp = require('ipp-encoder')
 var debug = require('debug')(require('../package').name)
@@ -34,7 +34,7 @@ module.exports = function (printer) {
 
   return printer
 
-  function onerror(err) {
+  function onerror (err) {
     if (printer.onerror) {
       return printer.onerror(err)
     }
@@ -42,7 +42,7 @@ module.exports = function (printer) {
     throw err
   }
 
-  function destroy() {
+  function destroy () {
     printer.stop()
     bonjour.destroy()
     server.destroy()
@@ -50,7 +50,7 @@ module.exports = function (printer) {
     debug('Printer server destroyed')
   }
 
-  function onrequest(req, res) {
+  function onrequest (req, res) {
     debug('HTTP request: %s %s', req.method, req.url)
 
     if (req.method !== 'POST') {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -32,6 +32,9 @@ function Printer (opts) {
   this.server = opts.server
   this.fallback = opts.fallback
 
+  // Events
+  this.onerror = opts.onerror
+
   bind(this)
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pump": "^1.0.1",
     "rc": "^1.1.6",
     "readable-stream": "^2.0.5",
+    "server-destroy": "^1.0.1",
     "unique-concat": "^0.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes:
- Added a `destroy` function to printer to shutdown the server, unmap port and bonjour service.
- Added support for attaching an `onerror` callback to the printer to catch initialization problems.

Referencing issue #17, I have made these changes, which enable the user to disable the printer without exiting the node process/closing the application. This is useful for an implementation where it's needed to make changes to the printer settings on "runtime".

Initializing a new printer without these changes would result in two possible exceptions, either the `EADDRINUSE` exception from node when the port/ip was already occupied. or a Bonjour exception stating that the "service name" `(printer.name)` was already taken. 

These exceptions could not be caught by wrapping the printer setup code in a `try...catch` block. So I added an `on('error')` callback to the server, which isn't perfect at this point because it doesn't catch the bonjour/zeroconf errors, but it does the basic job.

P.S: I know these changes might not be readily mergeable, especially because of the use of a new dependency for adding support for destroying the server (This is something that would be easy to add without it). And for extending the printer object in `bind.js`.

Anyways, I look forward to reading your comments!
